### PR TITLE
Fix new paragraph starting on `|`

### DIFF
--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -482,7 +482,7 @@ let paragraph : input -> Ast.nestable_block_element with_location =
    fun acc ->
     match npeek 2 input with
     | { value = `Single_newline ws; location }
-      :: { value = #token_that_always_begins_an_inline_element; _ }
+      :: { value = #token_that_always_begins_an_inline_element | `Bar; _ }
       :: _ ->
         junk input;
         let acc = Loc.at location (`Space ws) :: acc in


### PR DESCRIPTION
https://github.com/ocaml-doc/odoc-parser/pull/11#issuecomment-1428815644